### PR TITLE
Set `rust-version` for workspace members

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 keywords = ["svg", "render", "raster", "c-api"]
 license = "MPL-2.0"
 edition = "2021"
+rust-version = "1.67.1"
 workspace = "../.."
 
 [lib]

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 keywords = ["svg", "render", "raster"]
 license = "MPL-2.0"
 edition = "2021"
+rust-version = "1.67.1"
 description = "An SVG rendering library."
 repository = "https://github.com/RazrFalcon/resvg"
 exclude = ["tests"]

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 keywords = ["svg"]
 license = "MPL-2.0"
 edition = "2021"
+rust-version = "1.65.0"
 description = "An SVG simplification library."
 categories = ["multimedia::images"]
 repository = "https://github.com/RazrFalcon/resvg"


### PR DESCRIPTION
The edition of all crates in this repository are Rust 2021 (requires Rust 1.56.0 or later). So we can set the [`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) field for the `Cargo.toml` file. This makes it easier to check the crate's MSRV.

I didn't feel the need to set this field for crates which aren't published on [crates.io](https://crates.io/), so I didn't set the field for `codegen` and `explorer-thumbnailer` crates.