### PR TITLE
Fix #870: Added the stylesheet option to the C API

### DIFF
--- a/crates/c-api/examples/cairo/example.c
+++ b/crates/c-api/examples/cairo/example.c
@@ -15,12 +15,17 @@ int main(int argc, char **argv)
         abort();
     }
 
+    // Initialize resvg's library logging system
     resvg_init_log();
 
     resvg_options *opt = resvg_options_create();
     resvg_options_load_system_fonts(opt);
 
+    // Optionally, you can add some CSS to control the SVG rendering.
+    resvg_options_set_stylesheet(opt, "svg { fill: black; }");
+
     resvg_render_tree *tree;
+    // Construct a tree from the svg file and pass in some options
     int err = resvg_parse_tree_from_file(argv[1], opt, &tree);
     resvg_options_destroy(opt);
     if (err != RESVG_OK)
@@ -33,6 +38,7 @@ int main(int argc, char **argv)
     int width = (int)size.width;
     int height = (int)size.height;
 
+    // Using the dimension info, allocate enough pixels to account for the entire image
     cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 
     /* resvg doesn't support stride, so cairo_surface_t should have no padding */
@@ -50,9 +56,11 @@ int main(int argc, char **argv)
         surface_data[i + 2] = r;
     }
 
+    // Save image
     cairo_surface_write_to_png(surface, argv[2]);
-    cairo_surface_destroy(surface);
 
+    // De-initialize the allocated memory
+    cairo_surface_destroy(surface);
     resvg_tree_destroy(tree);
 
     return 0;

--- a/crates/c-api/lib.rs
+++ b/crates/c-api/lib.rs
@@ -158,17 +158,17 @@ pub extern "C" fn resvg_options_set_dpi(opt: *mut resvg_options, dpi: f32) {
     cast_opt(opt).dpi = dpi as f32;
 }
 
-/// @brief Sets a stylesheet path that will be used when resolving CSS attributes.
+/// @brief Provides the content of a stylesheet that will be used when resolving CSS attributes.
 ///
 /// Must be UTF-8. Can be set to NULL.
 ///
 /// Default: NULL
 #[no_mangle]
-pub extern "C" fn resvg_options_set_stylesheet(opt: *mut resvg_options, path: *const c_char) {
-    if path.is_null() {
+pub extern "C" fn resvg_options_set_stylesheet(opt: *mut resvg_options, content: *const c_char) {
+    if content.is_null() {
         cast_opt(opt).style_sheet = None;
     } else {
-        cast_opt(opt).style_sheet = Some(cstr_to_str(path).unwrap().into());
+        cast_opt(opt).style_sheet = Some(cstr_to_str(content).unwrap().into());
     }
 }
 

--- a/crates/c-api/lib.rs
+++ b/crates/c-api/lib.rs
@@ -158,6 +158,20 @@ pub extern "C" fn resvg_options_set_dpi(opt: *mut resvg_options, dpi: f32) {
     cast_opt(opt).dpi = dpi as f32;
 }
 
+/// @brief Sets a stylesheet path that will be used when resolving CSS attributes.
+///
+/// Must be UTF-8. Can be set to NULL.
+///
+/// Default: NULL
+#[no_mangle]
+pub extern "C" fn resvg_options_set_stylesheet(opt: *mut resvg_options, path: *const c_char) {
+    if path.is_null() {
+        cast_opt(opt).style_sheet = None;
+    } else {
+        cast_opt(opt).style_sheet = Some(cstr_to_str(path).unwrap().into());
+    }
+}
+
 /// @brief Sets the default font family.
 ///
 /// Will be used when no `font-family` attribute is set in the SVG.

--- a/crates/c-api/resvg.h
+++ b/crates/c-api/resvg.h
@@ -180,7 +180,7 @@ void resvg_options_set_dpi(resvg_options *opt, float dpi);
  *
  * Default: NULL
  */
-void resvg_options_set_stylesheet(resvg_options *opt, char *const content);
+void resvg_options_set_stylesheet(resvg_options *opt, const char *content);
 
 /**
  * @brief Sets the default font family.

--- a/crates/c-api/resvg.h
+++ b/crates/c-api/resvg.h
@@ -174,13 +174,13 @@ void resvg_options_set_resources_dir(resvg_options *opt, const char *path);
 void resvg_options_set_dpi(resvg_options *opt, float dpi);
 
 /**
- * @brief Sets a stylesheet path that will be used when resolving CSS attributes.
+ * @brief Provides the content of a stylesheet that will be used when resolving CSS attributes.
  *
  * Must be UTF-8. Can be set to NULL.
  *
  * Default: NULL
  */
-void resvg_options_set_stylesheet(resvg_options *opt, const char *path);
+void resvg_options_set_stylesheet(resvg_options *opt, char *const content);
 
 /**
  * @brief Sets the default font family.

--- a/crates/c-api/resvg.h
+++ b/crates/c-api/resvg.h
@@ -174,6 +174,15 @@ void resvg_options_set_resources_dir(resvg_options *opt, const char *path);
 void resvg_options_set_dpi(resvg_options *opt, float dpi);
 
 /**
+ * @brief Sets a stylesheet path that will be used when resolving CSS attributes.
+ *
+ * Must be UTF-8. Can be set to NULL.
+ *
+ * Default: NULL
+ */
+void resvg_options_set_stylesheet(resvg_options *opt, const char *path);
+
+/**
  * @brief Sets the default font family.
  *
  * Will be used when no `font-family` attribute is set in the SVG.


### PR DESCRIPTION
Fix #870. I made slight changes the [`resvg/crates/c-api/resvg.h`](https://github.com/linebender/resvg/blob/main/crates/c-api/resvg.h) and [`resvg/crates/c-api/lib.rs`](https://github.com/linebender/resvg/blob/main/crates/c-api/lib.rs). Take a look at #870 for more details.