### PR TITLE
Update to `itertools` 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "itertools"
-version = "0.7.11"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/crates/usvg/codegen/Cargo.toml
+++ b/crates/usvg/codegen/Cargo.toml
@@ -12,4 +12,4 @@ path = "main.rs"
 [dependencies]
 phf = "0.7.22"
 phf_codegen = "0.7.22"
-itertools = "0.7"
+itertools = "0.14"


### PR DESCRIPTION
This is only used in the `codegen` so it isn't all that important.
