### PR TITLE
Root without xmlns

### DIFF
--- a/crates/usvg/src/parser/svgtree/parse.rs
+++ b/crates/usvg/src/parser/svgtree/parse.rs
@@ -136,9 +136,8 @@ pub(crate) fn parse_tag_name(node: roxmltree::Node) -> Option<EId> {
         return None;
     }
 
-    match node.tag_name().namespace() {
-        None | Some(SVG_NS) => {}
-        _ => return None,
+    if !matches!(node.tag_name().namespace(), None | Some(SVG_NS)) {
+        return None;
     }
 
     EId::from_str(node.tag_name().name())

--- a/crates/usvg/src/parser/svgtree/parse.rs
+++ b/crates/usvg/src/parser/svgtree/parse.rs
@@ -136,8 +136,9 @@ pub(crate) fn parse_tag_name(node: roxmltree::Node) -> Option<EId> {
         return None;
     }
 
-    if node.tag_name().namespace() != Some(SVG_NS) {
-        return None;
+    match node.tag_name().namespace() {
+        None | Some(SVG_NS) => {}
+        _ => return None,
     }
 
     EId::from_str(node.tag_name().name())

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -490,3 +490,15 @@ fn path_transform_in_svg() {
         usvg::Transform::from_translate(100.0, 150.0)
     );
 }
+
+#[test]
+fn svg_without_xmlns() {
+    let svg = "
+    <svg viewBox='0 0 100 100'>
+        <rect x='0' y='0' width='10' height='10'/>
+    </svg>
+    ";
+
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    assert_eq!(tree.size(), usvg::Size::from_wh(100.0, 100.0).unwrap());
+}


### PR DESCRIPTION
Closes #847 

This PR implements support for SVG files without xmlns tag.
Existing tests pass.