### PR TITLE
Only allow releasing `v*` tags

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -3,7 +3,7 @@ name: "Tagged Release"
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I think this was missed in #891

Please also retag https://github.com/linebender/resvg/tree/0.45.0 as `v0.45.0`!