### PR TITLE
skip text layout in usvg with preserve-text arg

### DIFF
--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -578,6 +578,7 @@ fn parse_args() -> Result<Args, String> {
         font_resolver: usvg::FontResolver::default(),
         fontdb: Arc::new(fontdb::Database::new()),
         style_sheet,
+        preserve_text: false,
     };
 
     Ok(Args {

--- a/crates/usvg/src/main.rs
+++ b/crates/usvg/src/main.rs
@@ -432,6 +432,7 @@ fn process(args: Args) -> Result<(), String> {
         font_resolver: usvg::FontResolver::default(),
         fontdb: Arc::new(fontdb),
         style_sheet,
+        preserve_text: args.preserve_text,
     };
 
     let input_svg = match in_svg {

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -98,6 +98,11 @@ pub struct Options<'a> {
     /// A CSS stylesheet that should be injected into the SVG. Can be used to overwrite
     /// certain attributes.
     pub style_sheet: Option<String>,
+
+    /// Specifies whether to convert text nodes to paths. If true, will skip text
+    /// layout and rendering during parsing and ignores fonts. It mirrors
+    /// `preserve_text` in `usvg::writer::Options`.
+    pub preserve_text: bool,
 }
 
 impl Default for Options<'_> {
@@ -119,6 +124,7 @@ impl Default for Options<'_> {
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
             style_sheet: None,
+            preserve_text: false,
         }
     }
 }

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -140,7 +140,9 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if !state.opt.preserve_text && text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
+    if !state.opt.preserve_text
+        && text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none()
+    {
         return;
     }
 

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -140,7 +140,7 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
+    if !state.opt.preserve_text && text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
         return;
     }
 

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -34,6 +34,7 @@ fn resave_impl(name: &str, id_prefix: Option<String>, preserve_text: bool) {
     let tree = {
         let opt = usvg::Options {
             fontdb: GLOBAL_FONTDB.clone(),
+            preserve_text,
             ..Default::default()
         };
         usvg::Tree::from_str(&input_svg, &opt).unwrap()


### PR DESCRIPTION
Presently, when `--preserve-text` argument is passed to usvg cli, even though `<text>` nodes are passed as is in the output, usvg still does text layout / rendering as part of parsing. If all the fonts used in text elements are present, this works as expected. However, if any font is missing the associated text node is removed from the output.

We have a use case where we want to run usvg on a service that optimizes SVG files before being rendered with resvg in an environment where the fonts are present. As part of this optimization, we want the text nodes to be preserved. The current parsing logic in usvg prevents this.

This PR adds a fix that skips the text layout logic on text nodes if the `preserve-text` argument is passed to usvg cli. I can't think of any downsides to this approach but would love feedback on whether there is a better to way to accomplish this.

Thanks!
