### PR TITLE
Make `load_sub_svg` public

### DIFF
--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -327,7 +327,7 @@ fn get_image_data_format(data: &[u8]) -> Option<ImageFormat> {
 ///
 /// Unlike `Tree::from_*` methods, this one will also remove all `image` elements
 /// from the loaded SVG, as required by the spec.
-pub(crate) fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
+pub fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
     let sub_opt = Options {
         resources_dir: None,
         dpi: opt.dpi,

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -19,7 +19,7 @@ mod use_node;
 #[cfg(feature = "text")]
 mod text;
 
-pub use image::{ImageHrefDataResolverFn, ImageHrefResolver, ImageHrefStringResolverFn};
+pub use image::{ImageHrefDataResolverFn, ImageHrefResolver, ImageHrefStringResolverFn, load_sub_svg};
 pub use options::Options;
 pub(crate) use svgtree::{AId, EId};
 


### PR DESCRIPTION
The proposed change is a first step towards a new feature in typst, without duplicating code that is already present in usvg. (For context, see https://github.com/typst/typst/issues/6858).

By making `load_sub_svg` public, custom `ImageHrefResolver` implementations in other projects can reuse the `load_sub_svg` functionality when processing a linked SVG image. Reusing this code seems beneficial for both usvg and projects that use it.

Note that I have limited experience with contributions to Rust projects. If anything is not as expected, please let me know. I'm happy to learn and fix mistakes. 