### PR TITLE
poc: don't write empty nodes

### DIFF
--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -73,6 +73,15 @@ pub(crate) enum Units {
 
 // `Units` cannot have a default value, because it changes depending on an element.
 
+impl std::fmt::Display for Units {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Units::UserSpaceOnUse => write!(f, "userSpaceOnUse"),
+            Units::ObjectBoundingBox => write!(f, "objectBoundingBox"),
+        }
+    }
+}
+
 /// A visibility property.
 ///
 /// `visibility` attribute in the SVG.

--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -73,15 +73,6 @@ pub(crate) enum Units {
 
 // `Units` cannot have a default value, because it changes depending on an element.
 
-impl std::fmt::Display for Units {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Units::UserSpaceOnUse => write!(f, "userSpaceOnUse"),
-            Units::ObjectBoundingBox => write!(f, "objectBoundingBox"),
-        }
-    }
-}
-
 /// A visibility property.
 ///
 /// `visibility` attribute in the SVG.

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 the Resvg Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::fmt::{self, Display};
+use std::fmt::{Arguments, Display};
 use std::io::Write;
 
 use svgtypes::{parse_font_families, FontFamily};
@@ -188,7 +188,7 @@ impl<'a> LazyXmlWriter<'a> {
         }
     }
 
-    pub fn write_attribute_fmt(&mut self, name: &str, fmt: fmt::Arguments) {
+    pub fn write_attribute_fmt(&mut self, name: &str, fmt: Arguments) {
         self.init_node();
         self.xml.write_attribute_fmt(name, fmt);
     }
@@ -1057,6 +1057,7 @@ impl XmlWriterExt for XmlWriter {
         });
     }
 
+    // TODO: simplify
     fn write_units(&mut self, id: AId, units: Units, def: Units) {
         if units != def {
             self.write_attribute(

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use std::io::Write;
 
 use svgtypes::{parse_font_families, FontFamily};
-use xmlwriter::XmlWriter;
+use xmlwriter::{Options, XmlWriter};
 
 use crate::parser::{AId, EId};
 use crate::*;
@@ -707,7 +707,12 @@ fn write_element(node: &Node, is_clip_path: bool, opt: &WriteOptions, xml: &mut 
             xml.end_element();
         }
         Node::Group(ref g) => {
-            write_group_element(g, is_clip_path, opt, xml);
+            let mut fake_xml = XmlWriter::new(Options::default());
+            write_group_element(g, is_clip_path, opt, &mut fake_xml);
+            let fake_xml_str = fake_xml.end_document();
+            if fake_xml_str != "<g/>\n" {
+                write_group_element(g, is_clip_path, opt, xml);
+            }
         }
         Node::Text(ref text) => {
             if opt.preserve_text {

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -1059,7 +1059,13 @@ impl XmlWriterExt for XmlWriter {
 
     fn write_units(&mut self, id: AId, units: Units, def: Units) {
         if units != def {
-            self.write_attribute(id.to_str(), &units);
+            self.write_attribute(
+                id.to_str(),
+                match units {
+                    Units::UserSpaceOnUse => "userSpaceOnUse",
+                    Units::ObjectBoundingBox => "objectBoundingBox",
+                },
+            );
         }
     }
 

--- a/crates/usvg/tests/files/path-simple-case-empty-group-expected.svg
+++ b/crates/usvg/tests/files/path-simple-case-empty-group-expected.svg
@@ -1,0 +1,3 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <path id="my-path" fill="none" stroke="#008000" stroke-width="5" d="M 30 40 C 16 137 171 45 180 155"/>
+</svg>

--- a/crates/usvg/tests/files/path-simple-case-empty-group.svg
+++ b/crates/usvg/tests/files/path-simple-case-empty-group.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <path id="my-path" d="M 30 40 C 16 137 171 45 180 155" fill="none" stroke="green" stroke-width="5"/>
+    <g />
+</svg>

--- a/crates/usvg/tests/files/path-simple-case-empty-path-expected.svg
+++ b/crates/usvg/tests/files/path-simple-case-empty-path-expected.svg
@@ -1,0 +1,3 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <path id="my-path" fill="none" stroke="#008000" stroke-width="5" d="M 30 40 C 16 137 171 45 180 155"/>
+</svg>

--- a/crates/usvg/tests/files/path-simple-case-empty-path.svg
+++ b/crates/usvg/tests/files/path-simple-case-empty-path.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <path id="my-path" d="M 30 40 C 16 137 171 45 180 155" fill="none" stroke="green" stroke-width="5"/>
+    <path />
+</svg>

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -68,6 +68,11 @@ fn path_simple_case() {
 }
 
 #[test]
+fn path_simple_case_empty_group() {
+    resave("path-simple-case-empty-group");
+}
+
+#[test]
 fn ellipse_simple_case() {
     resave("ellipse-simple-case");
 }

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -73,6 +73,12 @@ fn path_simple_case_empty_group() {
 }
 
 #[test]
+fn path_simple_case_empty_path() {
+    // this tests will succeed because the parser removes empty paths (not the writer)
+    resave("path-simple-case-empty-path");
+}
+
+#[test]
 fn ellipse_simple_case() {
     resave("ellipse-simple-case");
 }

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -74,7 +74,7 @@ fn path_simple_case_empty_group() {
 
 #[test]
 fn path_simple_case_empty_path() {
-    // this tests will succeed because the parser removes empty paths (not the writer)
+    // this test will succeed because the parser removes empty paths (not the writer)
     resave("path-simple-case-empty-path");
 }
 


### PR DESCRIPTION
This is more like a Proof of concept about not writing nodes.

But it's very bad great for performance


```rust
let mut fake_xml = XmlWriter::new(Options::default());
write_group_element(g, is_clip_path, opt, &mut fake_xml);
let fake_xml_str = fake_xml.end_document();
if fake_xml_str != "<g/>\n" {
    write_group_element(g, is_clip_path, opt, xml);
}
```