### PR TITLE
fix: text nodes should inherit absolute transform

### DIFF
--- a/crates/usvg/src/text/flatten.rs
+++ b/crates/usvg/src/text/flatten.rs
@@ -26,6 +26,7 @@ fn push_outline_paths(
     builder: &mut tiny_skia_path::PathBuilder,
     new_children: &mut Vec<Node>,
     rendering_mode: ShapeRendering,
+    abs_transform: Transform,
 ) {
     let builder = mem::replace(builder, tiny_skia_path::PathBuilder::new());
 
@@ -38,7 +39,7 @@ fn push_outline_paths(
             span.paint_order,
             rendering_mode,
             Arc::new(p),
-            Transform::default(),
+            abs_transform,
         )
     }) {
         new_children.push(Node::Path(Box::new(path)));
@@ -48,6 +49,7 @@ fn push_outline_paths(
 pub(crate) fn flatten(text: &mut Text, cache: &mut Cache) -> Option<(Group, NonZeroRect)> {
     let mut new_children = vec![];
 
+    let abs_transform = text.abs_transform;
     let rendering_mode = resolve_rendering_mode(text);
 
     for span in &text.layouted {
@@ -90,13 +92,18 @@ pub(crate) fn flatten(text: &mut Text, cache: &mut Cache) -> Option<(Group, NonZ
             }
             // An SVG glyph. Will return the usvg node containing the glyph descriptions.
             else if let Some(node) = cache.fontdb_svg(glyph.font, glyph.id) {
-                push_outline_paths(span, &mut span_builder, &mut new_children, rendering_mode);
+                push_outline_paths(
+                    span,
+                    &mut span_builder,
+                    &mut new_children,
+                    rendering_mode,
+                    abs_transform,
+                );
 
                 let mut group = Group {
                     transform: glyph.svg_transform(),
                     ..Group::empty()
                 };
-                // TODO: Probably need to update abs_transform of children?
                 group.children.push(node);
                 group.calculate_bounding_boxes();
 
@@ -104,7 +111,13 @@ pub(crate) fn flatten(text: &mut Text, cache: &mut Cache) -> Option<(Group, NonZ
             }
             // A bitmap glyph.
             else if let Some(img) = cache.fontdb_raster(glyph.font, glyph.id) {
-                push_outline_paths(span, &mut span_builder, &mut new_children, rendering_mode);
+                push_outline_paths(
+                    span,
+                    &mut span_builder,
+                    &mut new_children,
+                    rendering_mode,
+                    abs_transform,
+                );
 
                 let transform = if img.is_sbix {
                     glyph.sbix_transform(
@@ -157,7 +170,13 @@ pub(crate) fn flatten(text: &mut Text, cache: &mut Cache) -> Option<(Group, NonZ
             }
         }
 
-        push_outline_paths(span, &mut span_builder, &mut new_children, rendering_mode);
+        push_outline_paths(
+            span,
+            &mut span_builder,
+            &mut new_children,
+            rendering_mode,
+            abs_transform,
+        );
 
         if let Some(path) = span.line_through.as_ref() {
             let mut path = path.clone();

--- a/crates/usvg/src/text/flatten.rs
+++ b/crates/usvg/src/text/flatten.rs
@@ -84,7 +84,8 @@ pub(crate) fn flatten(text: &mut Text, cache: &mut Cache) -> Option<(Group, NonZ
                     transform: glyph.colr_transform(),
                     ..Group::empty()
                 };
-                // TODO: Probably need to update abs_transform of children?
+                // TODO: Probably need to update abs_transform of children? Same
+                // for SVG and bitmap glyphs.
                 group.children.push(Node::Group(Box::new(tree.root)));
                 group.calculate_bounding_boxes();
 

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -561,8 +561,10 @@ fn text_as_path_should_inherit_group_transform() {
     ";
 
     let mut opts = usvg::Options::default();
-    let fontdb = opts.fontdb_mut();
-    fontdb.load_system_fonts();
+    // Maybe the `fonts` dir should be moved to `assets/fonts` dir
+    opts.fontdb_mut()
+        .load_fonts_dir(env!("CARGO_MANIFEST_DIR").to_string() + "/../resvg/tests/fonts");
+    opts.font_family = "Noto Sans".to_string();
 
     let tree = usvg::Tree::from_str(&svg, &opts).unwrap();
 

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -561,7 +561,6 @@ fn text_as_path_should_inherit_group_transform() {
     ";
 
     let mut opts = usvg::Options::default();
-    // Maybe the `fonts` dir should be moved to `assets/fonts` dir
     opts.fontdb_mut()
         .load_fonts_dir(env!("CARGO_MANIFEST_DIR").to_string() + "/../resvg/tests/fonts");
     opts.font_family = "Noto Sans".to_string();

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -547,3 +547,46 @@ fn no_text_nodes() {
     let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert!(!tree.has_text_nodes());
 }
+
+#[test]
+fn text_as_path_should_inherit_group_transform() {
+    let svg = "
+    <svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'>
+        <g transform='translate(20 20)'>
+            <g transform='translate(20 20)'>
+                <text x='32' y='100'>Text</text>
+            </g>
+        </g>
+    </svg>
+    ";
+
+    let mut opts = usvg::Options::default();
+    let fontdb = opts.fontdb_mut();
+    fontdb.load_system_fonts();
+
+    let tree = usvg::Tree::from_str(&svg, &opts).unwrap();
+
+    let usvg::Node::Group(group0) = &tree.root().children()[0] else {
+        unreachable!()
+    };
+    let usvg::Node::Group(group1) = &group0.children()[0] else {
+        unreachable!()
+    };
+    let usvg::Node::Text(text) = &group1.children()[0] else {
+        unreachable!()
+    };
+    let usvg::Node::Path(path) = &text.flattened().children()[0] else {
+        unreachable!()
+    };
+
+    let t = path.abs_transform();
+
+    assert_eq!(t.tx, 40.0);
+    assert_eq!(t.ty, 40.0);
+
+    assert_ne!(path.bounding_box(), path.abs_bounding_box());
+    assert_eq!(
+        path.bounding_box().transform(t).unwrap(),
+        path.abs_bounding_box()
+    );
+}

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -549,7 +549,7 @@ fn no_text_nodes() {
 }
 
 #[test]
-fn text_as_path_should_inherit_group_transform() {
+fn flattened_text_should_inherit_absolute_transform() {
     let svg = "
     <svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'>
         <g transform='translate(20 20)'>


### PR DESCRIPTION
The `abs_transform` is missing when rendering text as a path.