### PR TITLE
Prefer declared font-family entries during glyph fallback

### DIFF
--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -132,8 +132,8 @@ impl crate::Tree {
             #[cfg(feature = "text")]
             font_resolver: crate::FontResolver {
                 select_font: Box::new(|font, db| (opt.font_resolver.select_font)(font, db)),
-                select_fallback: Box::new(|c, used_fonts, db| {
-                    (opt.font_resolver.select_fallback)(c, used_fonts, db)
+                select_fallback: Box::new(|request, db| {
+                    (opt.font_resolver.select_fallback)(request, db)
                 }),
             },
             ..Options::default()

--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -15,9 +15,9 @@ use unicode_script::UnicodeScript;
 
 use crate::tree::{BBox, IsValidLength};
 use crate::{
-    AlignmentBaseline, ApproxZeroUlps, BaselineShift, DominantBaseline, Fill, FillRule, Font,
-    FontResolver, LengthAdjust, PaintOrder, Path, ShapeRendering, Stroke, Text, TextAnchor,
-    TextChunk, TextDecorationStyle, TextFlow, TextPath, TextSpan, WritingMode,
+    AlignmentBaseline, ApproxZeroUlps, BaselineShift, DominantBaseline, FallbackRequest, Fill,
+    FillRule, Font, FontResolver, LengthAdjust, PaintOrder, Path, ShapeRendering, Stroke, Text,
+    TextAnchor, TextChunk, TextDecorationStyle, TextFlow, TextPath, TextSpan, WritingMode,
 };
 
 /// A glyph that has already been positioned correctly.
@@ -254,7 +254,7 @@ pub(crate) fn layout_text(
         }
 
         for span in &chunk.spans {
-            let font = match fonts_cache.get(&span.font) {
+            let font = match span_font(span, &clusters, &fonts_cache, fontdb.as_ref()) {
                 Some(v) => v,
                 None => continue,
             };
@@ -264,7 +264,7 @@ pub(crate) fn layout_text(
             let mut span_ts = text_ts;
             span_ts = span_ts.pre_translate(x, y);
             if let TextFlow::Linear = chunk.text_flow {
-                let shift = resolve_baseline(span, font, text_node.writing_mode);
+                let shift = resolve_baseline(span, &font, text_node.writing_mode);
 
                 // In case of a horizontal flow, shift transform and not clusters,
                 // because clusters can be rotated and an additional shift will lead
@@ -287,7 +287,7 @@ pub(crate) fn layout_text(
                 };
 
                 if let Some(path) =
-                    convert_decoration(offset, span, font, decoration, &decoration_spans, span_ts)
+                    convert_decoration(offset, span, &font, decoration, &decoration_spans, span_ts)
                 {
                     bbox = bbox.expand(path.data.bounds());
                     underline = Some(path);
@@ -301,7 +301,7 @@ pub(crate) fn layout_text(
                 };
 
                 if let Some(path) =
-                    convert_decoration(offset, span, font, decoration, &decoration_spans, span_ts)
+                    convert_decoration(offset, span, &font, decoration, &decoration_spans, span_ts)
                 {
                     bbox = bbox.expand(path.data.bounds());
                     overline = Some(path);
@@ -315,7 +315,7 @@ pub(crate) fn layout_text(
                 };
 
                 if let Some(path) =
-                    convert_decoration(offset, span, font, decoration, &decoration_spans, span_ts)
+                    convert_decoration(offset, span, &font, decoration, &decoration_spans, span_ts)
                 {
                     bbox = bbox.expand(path.data.bounds());
                     line_through = Some(path);
@@ -415,6 +415,28 @@ fn convert_span(
     let bbox = bboxes.compute_tight_bounds()?.to_non_zero_rect()?;
 
     Some((span_clusters, bbox))
+}
+
+fn span_font(
+    span: &TextSpan,
+    clusters: &[GlyphCluster],
+    fonts_cache: &FontsCache,
+    fontdb: &fontdb::Database,
+) -> Option<Arc<ResolvedFont>> {
+    if let Some(font) = fonts_cache.get(&span.font) {
+        return Some(font.clone());
+    }
+
+    // A span can still have drawable glyphs when its declared font cannot be
+    // resolved, because another shaping pass may already have filled them via
+    // glyph fallback. In that case, use the first rendered glyph's font for
+    // span-level metrics such as baseline and decorations.
+    clusters
+        .iter()
+        .find(|cluster| span_contains(span, cluster.byte_idx))
+        .and_then(|cluster| cluster.glyphs.first())
+        .and_then(|glyph| fontdb.load_font(glyph.font))
+        .map(Arc::new)
 }
 
 fn collect_decoration_spans(span: &TextSpan, clusters: &[GlyphCluster]) -> Vec<DecorationSpan> {
@@ -1329,54 +1351,14 @@ pub(crate) fn shape_text(
         }
 
         if let Some(c) = missing {
-            let mut fallback_id = None;
-
-            let stretch = match font_node.stretch {
-                crate::FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
-                crate::FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
-                crate::FontStretch::Condensed => fontdb::Stretch::Condensed,
-                crate::FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
-                crate::FontStretch::Normal => fontdb::Stretch::Normal,
-                crate::FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
-                crate::FontStretch::Expanded => fontdb::Stretch::Expanded,
-                crate::FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
-                crate::FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
-            };
-
-            let style = match font_node.style {
-                crate::FontStyle::Normal => fontdb::Style::Normal,
-                crate::FontStyle::Italic => fontdb::Style::Italic,
-                crate::FontStyle::Oblique => fontdb::Style::Oblique,
-            };
-
-            for family in &font_node.families {
-                let fontdb_family = match family {
-                    crate::FontFamily::Serif => fontdb::Family::Serif,
-                    crate::FontFamily::SansSerif => fontdb::Family::SansSerif,
-                    crate::FontFamily::Cursive => fontdb::Family::Cursive,
-                    crate::FontFamily::Fantasy => fontdb::Family::Fantasy,
-                    crate::FontFamily::Monospace => fontdb::Family::Monospace,
-                    crate::FontFamily::Named(s) => fontdb::Family::Name(s),
-                };
-
-                let query = fontdb::Query {
-                    families: &[fontdb_family],
-                    weight: fontdb::Weight(font_node.weight),
-                    stretch,
-                    style,
-                };
-
-                if let Some(id) = fontdb.query(&query) {
-                    if !used_fonts.contains(&id) && fontdb.has_char(id, c) {
-                        fallback_id = Some(id);
-                        break;
-                    }
-                }
-            }
-
-            let fallback_id = fallback_id.or_else(|| {
-                (resolver.select_fallback)(c, &used_fonts, fontdb)
-            });
+            let fallback_id = (resolver.select_fallback)(
+                FallbackRequest {
+                    character: c,
+                    font: font_node,
+                    exclude_fonts: &used_fonts,
+                },
+                fontdb,
+            );
 
             let fallback_font = match fallback_id.and_then(|id| fontdb.load_font(id)) {
                 Some(v) => Arc::new(v),

--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -1378,9 +1378,14 @@ pub(crate) fn shape_text(
             )
             .unwrap_or_default();
 
-            // We assume, that shaping with an any font will produce the same amount of glyphs.
-            // This is incorrect, but good enough for now.
-            if glyphs.len() != fallback_glyphs.len() {
+            let all_matched = fallback_glyphs.iter().all(|g| !g.is_missing());
+            if !can_do_partial_fallback(text, &glyphs, &fallback_glyphs) {
+                if all_matched {
+                    // If the fallback can shape the full run but the cluster layout
+                    // no longer matches the current shaping, we have to keep the
+                    // fallback as a whole run to preserve shaping correctness.
+                    glyphs = fallback_glyphs;
+                }
                 break 'outer;
             }
 
@@ -1572,6 +1577,57 @@ impl Iterator for GlyphClusters<'_> {
         }
 
         Some((start..self.idx, cluster))
+    }
+}
+
+/// Returns whether it is safe to keep the existing run and only fill missing
+/// glyphs from `fallback_glyphs`.
+///
+/// This is intentionally conservative. We only allow partial fallback when both
+/// shapings still agree on the cluster boundaries and on the number of glyphs
+/// per cluster. If they diverge, a glyph-by-glyph merge can break shaping for
+/// the whole run, so callers should prefer whole-run fallback instead.
+fn can_do_partial_fallback(text: &str, glyphs: &[Glyph], fallback_glyphs: &[Glyph]) -> bool {
+    let mut glyph_clusters = GlyphClusters::new(glyphs);
+    let mut fallback_clusters = GlyphClusters::new(fallback_glyphs);
+
+    loop {
+        match (glyph_clusters.next(), fallback_clusters.next()) {
+            (Some((glyph_range, glyph_byte_idx)), Some((fallback_range, fallback_byte_idx))) => {
+                if glyph_byte_idx != fallback_byte_idx {
+                    return false;
+                }
+
+                let Some(glyph) = glyphs.get(glyph_range.start) else {
+                    return false;
+                };
+                let Some(fallback_glyph) = fallback_glyphs.get(fallback_range.start) else {
+                    return false;
+                };
+
+                if glyph.cluster_len != fallback_glyph.cluster_len {
+                    return false;
+                }
+
+                if glyph_range.len() != fallback_range.len() {
+                    return false;
+                }
+
+                let cluster_needs_fallback =
+                    glyphs[glyph_range.clone()].iter().any(Glyph::is_missing);
+                // For scripts where spacing and shaping are tightly coupled, even
+                // matching cluster boundaries are not enough to make partial
+                // fallback trustworthy. In those cases we keep the whole-run
+                // fallback path as the safer option.
+                if cluster_needs_fallback
+                    && !script_supports_letter_spacing(glyph_byte_idx.char_from(text).script())
+                {
+                    return false;
+                }
+            }
+            (None, None) => return true,
+            _ => return false,
+        }
     }
 }
 

--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -1396,13 +1396,6 @@ pub(crate) fn shape_text(
             )
             .unwrap_or_default();
 
-            let all_matched = fallback_glyphs.iter().all(|g| !g.is_missing());
-            if all_matched {
-                // Replace all glyphs when all of them were matched.
-                glyphs = fallback_glyphs;
-                break 'outer;
-            }
-
             // We assume, that shaping with an any font will produce the same amount of glyphs.
             // This is incorrect, but good enough for now.
             if glyphs.len() != fallback_glyphs.len() {

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -7,7 +7,7 @@ use fontdb::{Database, ID};
 use svgtypes::FontFamily;
 
 use self::layout::DatabaseExt;
-use crate::{Cache, Font, FontStretch, FontStyle, Text};
+use crate::{Cache, Font, Text};
 
 pub(crate) mod flatten;
 
@@ -36,19 +36,49 @@ pub mod layout;
 pub type FontSelectionFn<'a> =
     Box<dyn Fn(&Font, &mut Arc<Database>) -> Option<ID> + Send + Sync + 'a>;
 
+/// A fallback font selection request.
+#[derive(Clone, Copy, Debug)]
+pub struct FallbackRequest<'a> {
+    /// The character that needs a fallback font.
+    pub character: char,
+    /// The font specification of the current text span.
+    ///
+    /// This is provided as context for missing-glyph fallback selection. It
+    /// does not imply that the resolver controls text segmentation or the full
+    /// `font-family` cascade for the text run.
+    pub font: &'a Font,
+    /// Fonts that have already been used while shaping the current run.
+    pub exclude_fonts: &'a [ID],
+}
+
 /// A shorthand for [FontResolver]'s fallback selection function.
 ///
-/// This function receives a specific character, a list of already used fonts,
-/// and a font database. It should return the ID of a font that
+/// This function receives a fallback request and a font database. It should
+/// return the ID of a font that
 /// - is not any of the already used fonts
 /// - is as close as possible to the first already used font (if any)
 /// - supports the given character
+///
+/// The resolver is only responsible for selecting a candidate font for a
+/// missing glyph. It does not control text segmentation, shaping, or a full
+/// browser-style `font-family` cascade for the whole text run.
 ///
 /// The function can search the existing database, but can also load additional
 /// fonts dynamically. See the documentation of [`FontSelectionFn`] for more
 /// details.
 pub type FallbackSelectionFn<'a> =
-    Box<dyn Fn(char, &[ID], &mut Arc<Database>) -> Option<ID> + Send + Sync + 'a>;
+    Box<dyn Fn(FallbackRequest<'_>, &mut Arc<Database>) -> Option<ID> + Send + Sync + 'a>;
+
+fn fontdb_family(family: &FontFamily) -> fontdb::Family<'_> {
+    match family {
+        FontFamily::Serif => fontdb::Family::Serif,
+        FontFamily::SansSerif => fontdb::Family::SansSerif,
+        FontFamily::Cursive => fontdb::Family::Cursive,
+        FontFamily::Fantasy => fontdb::Family::Fantasy,
+        FontFamily::Monospace => fontdb::Family::Monospace,
+        FontFamily::Named(s) => fontdb::Family::Name(s),
+    }
+}
 
 /// A font resolver for `<text>` elements.
 ///
@@ -63,7 +93,11 @@ pub struct FontResolver<'a> {
     pub select_font: FontSelectionFn<'a>,
 
     /// Resolver function that will be used when selecting a fallback font for a
-    /// character.
+    /// missing character.
+    ///
+    /// This callback only selects fallback font candidates. It does not control
+    /// how text is split into runs or how shaping results are merged back into
+    /// the laid out text.
     pub select_fallback: FallbackSelectionFn<'a>,
 }
 
@@ -86,42 +120,17 @@ impl FontResolver<'_> {
         Box::new(move |font, fontdb| {
             let mut name_list = Vec::new();
             for family in &font.families {
-                name_list.push(match family {
-                    FontFamily::Serif => fontdb::Family::Serif,
-                    FontFamily::SansSerif => fontdb::Family::SansSerif,
-                    FontFamily::Cursive => fontdb::Family::Cursive,
-                    FontFamily::Fantasy => fontdb::Family::Fantasy,
-                    FontFamily::Monospace => fontdb::Family::Monospace,
-                    FontFamily::Named(s) => fontdb::Family::Name(s),
-                });
+                name_list.push(fontdb_family(family));
             }
 
             // Use the default font as fallback.
             name_list.push(fontdb::Family::Serif);
 
-            let stretch = match font.stretch {
-                FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
-                FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
-                FontStretch::Condensed => fontdb::Stretch::Condensed,
-                FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
-                FontStretch::Normal => fontdb::Stretch::Normal,
-                FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
-                FontStretch::Expanded => fontdb::Stretch::Expanded,
-                FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
-                FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
-            };
-
-            let style = match font.style {
-                FontStyle::Normal => fontdb::Style::Normal,
-                FontStyle::Italic => fontdb::Style::Italic,
-                FontStyle::Oblique => fontdb::Style::Oblique,
-            };
-
             let query = fontdb::Query {
                 families: &name_list,
                 weight: fontdb::Weight(font.weight),
-                stretch,
-                style,
+                stretch: font.stretch.into(),
+                style: font.style.into(),
             };
 
             let id = fontdb.query(&query);
@@ -142,21 +151,45 @@ impl FontResolver<'_> {
 
     /// Creates a default font fallback selection resolver.
     ///
-    /// The default implementation searches through the entire `fontdb`
+    /// The default implementation first prefers fonts from the declared
+    /// `font-family` list and then searches through the entire `fontdb`
     /// to find a font that has the correct style and supports the character.
+    /// This still operates as missing-glyph fallback, not as a full text-run
+    /// segmentation strategy.
     pub fn default_fallback_selector() -> FallbackSelectionFn<'static> {
-        Box::new(|c, exclude_fonts, fontdb| {
-            let base_font_id = exclude_fonts[0];
+        Box::new(|request, fontdb| {
+            let Some(&base_font_id) = request.exclude_fonts.first() else {
+                return None;
+            };
+
+            for family in request.font.families() {
+                let family = fontdb_family(family);
+                let query = fontdb::Query {
+                    families: &[family],
+                    weight: fontdb::Weight(request.font.weight()),
+                    stretch: request.font.stretch().into(),
+                    style: request.font.style().into(),
+                };
+
+                if let Some(id) = fontdb.query(&query) {
+                    if !request.exclude_fonts.contains(&id)
+                        && fontdb.has_char(id, request.character)
+                    {
+                        return Some(id);
+                    }
+                }
+            }
+
+            let base_face = fontdb.face(base_font_id)?;
 
             // Iterate over fonts and check if any of them support the specified char.
             for face in fontdb.faces() {
                 // Ignore fonts, that were used for shaping already.
-                if exclude_fonts.contains(&face.id) {
+                if request.exclude_fonts.contains(&face.id) {
                     continue;
                 }
 
                 // Check that the new face has the same style.
-                let base_face = fontdb.face(base_font_id)?;
                 if base_face.style != face.style
                     && base_face.weight != face.weight
                     && base_face.stretch != face.stretch
@@ -164,7 +197,7 @@ impl FontResolver<'_> {
                     continue;
                 }
 
-                if !fontdb.has_char(face.id, c) {
+                if !fontdb.has_char(face.id, request.character) {
                     continue;
                 }
 
@@ -213,4 +246,61 @@ pub(crate) fn convert(text: &mut Text, resolver: &FontResolver, cache: &mut Cach
     text.abs_stroke_bounding_box = stroke_bbox.transform(text.abs_transform)?.to_rect();
 
     Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use once_cell::sync::Lazy;
+
+    use super::*;
+
+    static TEST_FONTDB: Lazy<Arc<Database>> = Lazy::new(|| {
+        let mut fontdb = Database::new();
+        let fonts_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../resvg/tests/fonts");
+        fontdb.load_fonts_dir(fonts_dir);
+        Arc::new(fontdb)
+    });
+
+    fn test_font(families: &[&str]) -> Font {
+        Font {
+            families: families
+                .iter()
+                .map(|family| FontFamily::Named((*family).to_string()))
+                .collect(),
+            style: crate::FontStyle::Normal,
+            stretch: crate::FontStretch::Normal,
+            weight: 400,
+            variations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn default_fallback_selector_prefers_declared_families() {
+        let mut fontdb = TEST_FONTDB.clone();
+        let font = test_font(&["Noto Sans", "Noto Sans Devanagari"]);
+
+        let select_font = FontResolver::default_font_selector();
+        let base_font_id = select_font(&font, &mut fontdb).unwrap();
+
+        let select_fallback = FontResolver::default_fallback_selector();
+        let fallback_id = select_fallback(
+            FallbackRequest {
+                character: 'क',
+                font: &font,
+                exclude_fonts: &[base_font_id],
+            },
+            &mut fontdb,
+        )
+        .unwrap();
+
+        let face = fontdb.face(fallback_id).unwrap();
+        assert!(
+            face.families
+                .iter()
+                .any(|family| family.0 == "Noto Sans Devanagari")
+        );
+    }
 }

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -1,8 +1,20 @@
 // Copyright 2018 the Resvg Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use once_cell::sync::Lazy;
 use tiny_skia_path::Rect;
 use usvg::Color;
+
+static TEST_FONTDB: Lazy<Arc<usvg::fontdb::Database>> = Lazy::new(|| {
+    let mut fontdb = usvg::fontdb::Database::new();
+    let fonts_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../resvg/tests/fonts");
+    fontdb.load_fonts_dir(fonts_dir);
+    Arc::new(fontdb)
+});
 
 #[test]
 fn clippath_with_invalid_child() {
@@ -546,4 +558,77 @@ fn no_text_nodes() {
 
     let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert!(!tree.has_text_nodes());
+}
+
+#[test]
+fn custom_fallback_resolver_receives_request_before_default_policy() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let fallback_calls = calls.clone();
+
+    let opt = usvg::Options {
+        fontdb: TEST_FONTDB.clone(),
+        font_resolver: usvg::FontResolver {
+            select_font: usvg::FontResolver::default_font_selector(),
+            select_fallback: Box::new(move |request, _db| {
+                fallback_calls.fetch_add(1, Ordering::SeqCst);
+
+                assert_eq!(request.character, 'क');
+                assert_eq!(request.exclude_fonts.len(), 1);
+                assert_eq!(
+                    request
+                        .font
+                        .families()
+                        .iter()
+                        .map(|family| family.to_string())
+                        .collect::<Vec<_>>(),
+                    vec![
+                        "\"Noto Sans\"".to_string(),
+                        "\"Noto Sans Devanagari\"".to_string(),
+                    ]
+                );
+
+                None
+            }),
+        },
+        ..usvg::Options::default()
+    };
+
+    let svg = "
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 20'>
+        <text x='0' y='16' font-family='Noto Sans, Noto Sans Devanagari'>क</text>
+    </svg>
+    ";
+
+    let _ = usvg::Tree::from_str(&svg, &opt).unwrap();
+    assert!(calls.load(Ordering::SeqCst) > 0);
+}
+
+#[test]
+fn invalid_child_font_family_keeps_fallback_glyphs_visible() {
+    let opt = usvg::Options {
+        fontdb: TEST_FONTDB.clone(),
+        ..usvg::Options::default()
+    };
+
+    let svg = "
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 40'>
+        <text x='0' y='24' font-family='Noto Sans'>
+            data <tspan font-family='Invalid'>你好</tspan> data
+        </text>
+    </svg>
+    ";
+
+    let tree = usvg::Tree::from_str(svg, &opt).unwrap();
+    let usvg::Node::Text(text) = &tree.root().children()[0] else {
+        unreachable!()
+    };
+
+    let rendered_text = text
+        .layouted()
+        .iter()
+        .flat_map(|span| span.positioned_glyphs.iter())
+        .map(|glyph| glyph.text.as_str())
+        .collect::<String>();
+
+    assert!(rendered_text.contains("你好"));
 }


### PR DESCRIPTION
## Summary

This changes glyph fallback to prefer fonts from the declared `font-family` list, while preserving the control of custom `FontResolver::select_fallback` implementations.

The main design change is to pass the current span's `Font` into fallback resolution via a new `FallbackRequest` struct. This lets the default fallback resolver consider the declared family list without hardcoding that policy inside the text layout code.

## Design

The key question here was where the "prefer declared families during fallback" policy should live.

I considered two approaches:

1. Keep the family-first lookup inside `shape_text`
2. Move that policy into the default fallback resolver and give resolvers the context they need

I chose the second approach.

### Why this is a better fit

`shape_text` is part of layout execution. It should ask for a fallback candidate, but it should not embed policy that overrides user-provided fallback selection.

The previous approach introduced a family-first loop in layout before calling `select_fallback`. That had two problems:

- It bypassed custom `FontResolver::select_fallback` callbacks whenever one of the declared families already matched
- It made the default fallback policy effectively un-overridable from the public API

By introducing `FallbackRequest`, the default resolver can now implement family-first fallback itself, and custom resolvers receive the same context and remain fully in control.

This keeps the boundary cleaner:

- layout is responsible for detecting missing glyphs and attempting fallback shaping
- the resolver is responsible for selecting fallback font candidates
- the default resolver can prefer declared families, but custom resolvers are not bypassed

### Why `FallbackRequest` instead of just adding `&Font` as another parameter

I used a request struct instead of extending the callback with another positional parameter because this API is likely to need more context over time.

A request object makes that evolution easier and keeps the callback signature readable. It also makes the intent clearer: the fallback resolver is handling a specific missing-glyph fallback request, not a general text-layout task.

### Scope and non-goals

This PR does not turn `FontResolver` into a full browser-style font cascade or run segmentation API.

The fallback resolver still only selects candidate fonts for missing glyphs. It does not control:

- text segmentation
- shaping strategy
- how entire runs are split into `(text, font)` sequences

That distinction is important and matches the intended scope of `FontResolver`.

This PR also does not attempt to solve cluster-aware fallback merging. The existing fallback merge behavior is left as-is.

## What changed

- Added `FallbackRequest` to carry fallback context:
  - missing character
  - current span `Font`
  - already used font IDs
- Changed `FallbackSelectionFn` to take `FallbackRequest`
- Moved the family-first fallback policy out of `shape_text` and into `FontResolver::default_fallback_selector`
- Updated layout code to always call `select_fallback` with the full request instead of doing its own pre-selection
- Updated nested parser forwarding code to match the new callback signature
- Clarified the API docs to state that fallback selection is still missing-glyph candidate selection, not full text-run segmentation or browser-style font cascading
- Preserved fallback-shaped child glyphs even when the child span's declared `font-family` cannot be resolved, so invalid child family lists no longer make already-resolved fallback text disappear
- Added tests for:
  - default resolver preferring declared families during fallback
  - custom fallback resolvers still being invoked before any default family-first policy is applied
  - invalid child font families keeping fallback glyphs visible

## Behavioral impact

For the default resolver:

- fallback now prefers fonts from the declared `font-family` list when possible

For custom resolvers:

- custom `select_fallback` callbacks are no longer bypassed by layout-level family-first logic
- the callback now receives the current `Font` via `FallbackRequest`, so it can make family-aware decisions itself

## Breaking change

This changes the public fallback callback signature from:

```rs
Fn(char, &[ID], &mut Arc<Database>) -> Option<ID>
```

to:

```rs
Fn(FallbackRequest<'_>, &mut Arc<Database>) -> Option<ID>
```

Custom `FontResolver::select_fallback` implementations will need to be updated accordingly.

## Testing

Verified with:

```sh
cargo test -p usvg
```

<img width="1400" height="1420" alt="tspan-font-family-sheet-1" src="https://github.com/user-attachments/assets/c5789f30-a2c6-4f93-8702-7230d1021f94" />
<img width="1400" height="1040" alt="tspan-font-family-sheet-2" src="https://github.com/user-attachments/assets/3d2e9254-bcac-401d-afdc-e6d4d7e2c356" />
