### PR TITLE
Fix `fr` resolution for referenced radial gradients

### DIFF
--- a/crates/usvg/src/parser/paint_server.rs
+++ b/crates/usvg/src/parser/paint_server.rs
@@ -476,6 +476,7 @@ fn resolve_rg_attr<'a, 'input>(node: SvgNode<'a, 'input>, name: AId) -> SvgNode<
             | (AId::R,  EId::RadialGradient)
             | (AId::Fx, EId::RadialGradient)
             | (AId::Fy, EId::RadialGradient)
+            | (AId::Fr, EId::RadialGradient)
             // Other attributes can be resolved
             // from any kind of gradient.
             | (AId::GradientUnits, EId::LinearGradient)


### PR DESCRIPTION
The `resolve_rg_attr` function resolves gradient attributes via `href` links, but was missing `AId::Fr` from the coordinate attribute match arm. While `Cx`, `Cy`, `R`, `Fx`, and `Fy` were all handled, `Fr` was overlooked.

When a radial gradient references another via `href` , the `fr` attribute on the base gradient was never resolved, silently falling back to 0. This caused the focal radius to be ignored, making the gradient render as if `fr="0"` regardless of the actual value.

**Example**

```xml
<svg viewBox="0 0 100 100" width="100pt" height="100pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
    <radialGradient id="base" spreadMethod="pad" gradientUnits="userSpaceOnUse" cx="0.5" cy="0.5" r="0.5" fx="0.5" fy="0.5" fr="0.4">
      <stop offset="0%" stop-color="red"/>
      <stop offset="100%" stop-color="blue"/>
    </radialGradient>
    <radialGradient gradientTransform="scale(100)" id="ref" href="#base" xlink:href="#base"/>
  </defs>
  <rect width="100" height="100" fill="url(#ref)"/>
</svg>
```

The `fr="0.4"` on the base gradient was ignored.

