### PR TITLE
Add `Tree::intrinsic_dimensions` exposing declared root `width`/`height`/`viewBox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This changelog also contains important changes in dependencies.
 
 ## [Unreleased]
 
+### Added
+
+- `Tree::intrinsic_dimensions`, exposing the root `width`/`height`/`viewBox` attributes
+  as declared, with absent attributes as `None` and percentages unresolved. This allows
+  embedders to implement their own sizing rules, such as the CSS default sizing algorithm
+  for replaced elements.
+- `svgtypes` is now re-exported from `usvg`.
+
 ## [0.48.1] 2026-08-02
 
 This release has an MSRV of 1.85.0 for `usvg` and `resvg` and the C API.

--- a/crates/usvg/src/lib.rs
+++ b/crates/usvg/src/lib.rs
@@ -64,6 +64,7 @@ pub use text::*;
 pub use tree::*;
 
 pub use roxmltree;
+pub use svgtypes;
 
 #[cfg(feature = "text")]
 pub use fontdb;

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -398,8 +398,15 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
             _ => None,
         });
 
+    let intrinsic_dimensions = IntrinsicDimensions {
+        width: svg.attribute::<Length>(AId::Width),
+        height: svg.attribute::<Length>(AId::Height),
+        view_box: svg.parse_viewbox(),
+    };
+
     let mut tree = Tree {
         size,
+        intrinsic_dimensions,
         root: Group::empty(),
         linear_gradients: Vec::new(),
         radial_gradients: Vec::new(),

--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -1587,11 +1587,29 @@ impl Image {
     }
 }
 
+/// Dimensions declared on the root `<svg>` element, before any resolution.
+///
+/// Unlike [`Tree::size`], which always produces a concrete size, this
+/// preserves what the SVG actually declared: absent attributes are `None` and
+/// percentage lengths are kept unresolved. This allows embedders (e.g. HTML
+/// renderers) to apply their own sizing rules, such as the CSS default sizing
+/// algorithm for replaced elements.
+#[derive(Clone, Copy, Debug)]
+pub struct IntrinsicDimensions {
+    /// The root `width` attribute, if declared. Percentages are unresolved.
+    pub width: Option<svgtypes::Length>,
+    /// The root `height` attribute, if declared. Percentages are unresolved.
+    pub height: Option<svgtypes::Length>,
+    /// The root `viewBox` rectangle, if declared and valid.
+    pub view_box: Option<NonZeroRect>,
+}
+
 /// A nodes tree container.
 #[allow(missing_debug_implementations)]
 #[derive(Clone, Debug)]
 pub struct Tree {
     pub(crate) size: Size,
+    pub(crate) intrinsic_dimensions: IntrinsicDimensions,
     pub(crate) root: Group,
     pub(crate) linear_gradients: Vec<Arc<LinearGradient>>,
     pub(crate) radial_gradients: Vec<Arc<RadialGradient>>,
@@ -1616,6 +1634,14 @@ impl Tree {
     /// to retrieve it instead.
     pub fn size(&self) -> Size {
         self.size
+    }
+
+    /// The dimensions declared on the root `<svg>` element, with absent
+    /// attributes as `None` and percentages unresolved.
+    ///
+    /// See [`IntrinsicDimensions`] for details.
+    pub fn intrinsic_dimensions(&self) -> IntrinsicDimensions {
+        self.intrinsic_dimensions
     }
 
     /// The root element of the SVG tree.

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -675,3 +675,39 @@ fn nested_svg_abs_bounding_box() {
         Rect::from_xywh(10.0, 20.0, 10.0, 10.0).unwrap()
     );
 }
+
+#[test]
+fn intrinsic_dimensions_all_declared() {
+    let svg =
+        "<svg xmlns='http://www.w3.org/2000/svg' width='100' height='50%' viewBox='0 0 200 100'/>";
+    let tree = usvg::Tree::from_str(svg, &usvg::Options::default()).unwrap();
+    let dims = tree.intrinsic_dimensions();
+    assert_eq!(
+        dims.width,
+        Some(usvg::svgtypes::Length::new(
+            100.0,
+            usvg::svgtypes::LengthUnit::None
+        ))
+    );
+    assert_eq!(
+        dims.height,
+        Some(usvg::svgtypes::Length::new(
+            50.0,
+            usvg::svgtypes::LengthUnit::Percent
+        ))
+    );
+    assert_eq!(
+        dims.view_box,
+        usvg::tiny_skia_path::NonZeroRect::from_xywh(0.0, 0.0, 200.0, 100.0)
+    );
+}
+
+#[test]
+fn intrinsic_dimensions_none_declared() {
+    let svg = "<svg xmlns='http://www.w3.org/2000/svg'/>";
+    let tree = usvg::Tree::from_str(svg, &usvg::Options::default()).unwrap();
+    let dims = tree.intrinsic_dimensions();
+    assert_eq!(dims.width, None);
+    assert_eq!(dims.height, None);
+    assert!(dims.view_box.is_none());
+}


### PR DESCRIPTION
Exposes raw/unresolved `width`/`height`/`viewBox` on `Tree`.

This is necessary to correctly size SVGs within an HTML document (e.g. in Servo/Blitz) in the case that `width` or `height` are defined as a percentage. In that case, resvg's existing approach of eagerly resolving sizes doesn't work, as you cannot correctly resolve the sizes until you have a basis to resolve the percentages against (which are only computed as part of layout).

Exposed as a separate method to the existing `width()` and `height()` methods as it's a little bit of an advanced use case, and the existing methods make some sense for the simple cases.
