### PR TITLE
Percent-decode local image hrefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog also contains important changes in dependencies.
 
 ## [Unreleased]
 
+### Fixed
+
+- Local `<image>` hrefs are now percent-decoded when the raw href doesn't point to an existing file. (#1073)
+
 ## [0.48.1] 2026-08-02
 
 This release has an MSRV of 1.85.0 for `usvg` and `resvg` and the C API.

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -84,7 +84,17 @@ impl ImageHrefResolver<'_> {
     /// [Options::resources_dir](crate::Options::resources_dir).
     pub fn default_string_resolver() -> ImageHrefStringResolverFn<'static> {
         Box::new(move |href: &str, opts: &Options| {
-            let path = opts.get_abs_path(std::path::Path::new(href));
+            let mut path = opts.get_abs_path(std::path::Path::new(href));
+
+            // `href` is an IRI and therefore can be percent-encoded.
+            // Editors like Inkscape store non-ASCII file names this way.
+            // A file name can contain a literal `%` as well,
+            // so the raw path is checked first.
+            if !path.exists() {
+                if let Some(decoded) = percent_decode(href) {
+                    path = opts.get_abs_path(std::path::Path::new(&decoded));
+                }
+            }
 
             if path.exists() {
                 let data = match std::fs::read(&path) {
@@ -118,6 +128,39 @@ impl std::fmt::Debug for ImageHrefResolver<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("ImageHrefResolver { .. }")
     }
+}
+
+/// Decodes percent-encoded characters in an IRI.
+///
+/// Returns `None` when there is nothing to decode
+/// or when the decoded data is not a valid UTF-8 string.
+/// Invalid escape sequences are preserved as is.
+fn percent_decode(href: &str) -> Option<String> {
+    if !href.contains('%') {
+        return None;
+    }
+
+    fn hex_digit(c: u8) -> Option<u8> {
+        (c as char).to_digit(16).map(|d| d as u8)
+    }
+
+    let src = href.as_bytes();
+    let mut dst = Vec::with_capacity(src.len());
+    let mut i = 0;
+    while i < src.len() {
+        if src[i] == b'%' && i + 2 < src.len() {
+            if let (Some(h), Some(l)) = (hex_digit(src[i + 1]), hex_digit(src[i + 2])) {
+                dst.push(h * 16 + l);
+                i += 3;
+                continue;
+            }
+        }
+
+        dst.push(src[i]);
+        i += 1;
+    }
+
+    String::from_utf8(dst).ok()
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -572,6 +572,63 @@ fn image_bbox_with_parent_transform() {
     );
 }
 
+// An external image used by the tests below.
+const EXTERNAL_IMAGE: &str = "<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'>\
+    <rect width='10' height='10'/>\
+</svg>";
+
+// Creates an empty directory for external image tests.
+fn resources_dir(name: &str) -> std::path::PathBuf {
+    let dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join(name);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+// Checks that an `<image>` with the provided `href` was resolved
+// relative to `resources_dir`.
+fn is_image_resolved(dir: &std::path::Path, href: &str) -> bool {
+    let svg = format!(
+        "<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>\
+            <image href='{}' width='100' height='100'/>\
+        </svg>",
+        href
+    );
+
+    let opt = usvg::Options {
+        resources_dir: Some(dir.to_path_buf()),
+        ..usvg::Options::default()
+    };
+
+    let tree = usvg::Tree::from_str(&svg, &opt).unwrap();
+    let Some(usvg::Node::Group(group)) = tree.root().children().first() else {
+        return false;
+    };
+    matches!(group.children().first(), Some(usvg::Node::Image(_)))
+}
+
+#[test]
+fn percent_encoded_image_href() {
+    let dir = resources_dir("percent-encoded-image-href");
+    std::fs::create_dir(dir.join("images")).unwrap();
+    std::fs::write(dir.join("images").join("细节3-mine.svg"), EXTERNAL_IMAGE).unwrap();
+
+    // Editors like Inkscape store non-ASCII file names percent-encoded.
+    assert!(is_image_resolved(
+        &dir,
+        "images/%E7%BB%86%E8%8A%823-mine.svg"
+    ));
+}
+
+#[test]
+fn image_href_with_literal_percent() {
+    let dir = resources_dir("image-href-with-literal-percent");
+    // `%41` is a valid escape sequence for `A`, but here it's just a file name.
+    std::fs::write(dir.join("%41.svg"), EXTERNAL_IMAGE).unwrap();
+
+    assert!(is_image_resolved(&dir, "%41.svg"));
+}
+
 #[test]
 fn no_text_nodes() {
     let svg = "


### PR DESCRIPTION
Fixes #1073.

### The bug

An `<image>` `href` is an IRI, so SVG editors percent-encode characters that
can't appear in one. Inkscape, for example, writes a local file named
`images/细节3-mine.png` as:

```xml
<image href="images/%E7%BB%86%E8%8A%823-mine.png" .../>
```

`ImageHrefResolver::default_string_resolver` passed that string straight to
`Options::get_abs_path` and then to `Path::exists`, so it looked for a file
literally named `%E7%BB%86%E8%8A%823-mine.png`. That file doesn't exist, and the
image was silently dropped:

```
Warning (in usvg::parser::image:110): 'images/%E7%BB%86%E8%8A%823-mine.png' is not a path to an image.
```

Reproducer (from the issue):

```
repro/
  encoded.svg      <image href="images/%E7%BB%86%E8%8A%823-mine.png" .../>
  images/细节3-mine.png
```

```
resvg --resources-dir ./repro ./repro/encoded.svg out.png
```

The same SVG with the decoded file name in the `href` renders fine.

### The fix

The default string resolver now percent-decodes the `href` and retries, using a
small local decoder (no new dependency).

The raw path is still checked first and the decoded path is only used as a
fallback, so a file whose name genuinely contains a percent sign — including
one that happens to look like a valid escape sequence, e.g. `%41.svg` — keeps
resolving exactly as before. Nothing that works today changes behaviour; this
only adds a second attempt for hrefs that currently fail. Invalid escape
sequences are left as-is, and if the decoded bytes aren't valid UTF-8 the
original path is kept.

This is fixed in the resolver rather than in the parser because that's where the
href is turned into a filesystem path, and it keeps custom
`ImageHrefResolver`s free to do their own thing.

### Deliberately out of scope

- `data:` URLs — they're handled by `resolve_data` and never touch the filesystem.
- `fontdb`/`resources_dir` path handling in general.
- Interpreting the href as a full URL (scheme, authority, query, `+` as space).
  usvg doesn't resolve URLs, and treating `+` as a space would break existing
  file names.

### Verification

New tests in `crates/usvg/tests/parser.rs`. Before the change:

```
running 2 tests
test percent_encoded_image_href ... FAILED
test image_href_with_literal_percent ... ok

---- percent_encoded_image_href stdout ----
thread 'percent_encoded_image_href' panicked at crates/usvg/tests/parser.rs:617:5:
assertion failed: is_image_resolved(&dir, "images/%E7%BB%86%E8%8A%823-mine.svg")

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 27 filtered out
```

After:

```
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo test --all --release` is green: 1730 render tests, 29 usvg parser tests,
31 usvg writer tests, 2 resvg unit tests, 1 doctest. `cargo fmt --all --check`,
`.github/copyright.sh` and `typos` are clean (the two `typos` hits on `main` —
`oppen` in the changelog and `planed` in `parser/filter.rs` — are pre-existing
and untouched). Also built with an older toolchain to check nothing here needs a
recent compiler.
