### PR TITLE
Add aarch64 release artifacts for Linux and Windows

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -32,12 +32,12 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
   release-linux:
-    name: Release Linux
+    name: Release Linux (x86_64)
     runs-on: ubuntu-latest
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Build resvg
         run: cargo build --release
@@ -57,13 +57,9 @@ jobs:
           cp resvg-linux-x86_64.tar.gz ../../bin/
           cp usvg-linux-x86_64.tar.gz ../../bin/
 
-      - name: Get version
-        id: get_version
-        uses: battila7/get-version-action@v2
-
       - name: Make vendored archive
         run: |
-          VERSION=${{ steps.get_version.outputs.version-without-v }}
+          VERSION=${GITHUB_REF_NAME#v}
           echo $VERSION
           git clone https://github.com/linebender/resvg resvg-$VERSION
           cd resvg-"$VERSION"
@@ -79,19 +75,52 @@ jobs:
           cp resvg-"$VERSION".tar.xz bin/
 
       - name: Upload binaries
-        uses: alexellis/upload-assets@0.2.2
+        uses: alexellis/upload-assets@0.5.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["bin/*"]'
+
+  release-linux-aarch64:
+    name: Release Linux (aarch64)
+    runs-on: ubuntu-24.04-arm
+    needs: ["create-release"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build resvg
+        run: cargo build --release
+
+      - name: Build usvg
+        working-directory: crates/usvg
+        run: cargo build --release
+
+      - name: Collect
+        working-directory: target/release
+        run: |
+          strip -s resvg
+          strip -s usvg
+          tar czf resvg-linux-aarch64.tar.gz resvg
+          tar czf usvg-linux-aarch64.tar.gz usvg
+          mkdir ../../bin
+          cp resvg-linux-aarch64.tar.gz ../../bin/
+          cp usvg-linux-aarch64.tar.gz ../../bin/
+
+      - name: Upload binaries
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["bin/*"]'
 
   release-windows:
-    name: Release Windows
+    name: Release Windows (x86_64)
     runs-on: windows-latest
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       # Toolchain is stable-x86_64-pc-windows-msvc by default. No need to change it.
 
@@ -141,7 +170,48 @@ jobs:
           cp tools/explorer-thumbnailer/install/resvg-explorer-extension.exe bin/
 
       - name: Upload binaries
-        uses: alexellis/upload-assets@0.2.2
+        uses: alexellis/upload-assets@0.5.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["bin/*"]'
+
+  release-windows-aarch64:
+    name: Release Windows (aarch64)
+    runs-on: windows-11-arm
+    needs: ["create-release"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Toolchain is stable-aarch64-pc-windows-msvc by default. No need to change it.
+
+      - name: Build resvg
+        env:
+          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
+        run: cargo build --release
+
+      - name: Build usvg
+        working-directory: crates/usvg
+        env:
+          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
+        run: cargo build --release
+
+      - name: Compress
+        working-directory: target/release
+        shell: cmd
+        run: |
+          7z a -tzip -mx9 resvg-win-aarch64.zip resvg.exe
+          7z a -tzip -mx9 usvg-win-aarch64.zip usvg.exe
+
+      - name: Collect
+        run: |
+          mkdir bin
+          cp target/release/resvg-win-aarch64.zip bin/
+          cp target/release/usvg-win-aarch64.zip bin/
+
+      - name: Upload binaries
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -153,7 +223,7 @@ jobs:
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       # Some weird CI glitch. Make sure we have the latest Rust.
       - name: Install latest stable toolchain
@@ -183,7 +253,7 @@ jobs:
           cp target/release/usvg-macos-aarch64.zip bin/
 
       - name: Upload binaries
-        uses: alexellis/upload-assets@0.2.2
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -195,7 +265,7 @@ jobs:
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       # Some weird CI glitch. Make sure we have the latest Rust.
       - name: Install latest stable toolchain
@@ -225,7 +295,7 @@ jobs:
           cp target/release/usvg-macos-x86_64.zip bin/
 
       - name: Upload binaries
-        uses: alexellis/upload-assets@0.2.2
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Adds native aarch64 builds to the release workflow.

- **Linux aarch64** on the `ubuntu-24.04-arm` runner → `resvg-linux-aarch64.tar.gz`, `usvg-linux-aarch64.tar.gz`
- **Windows aarch64** on the `windows-11-arm` runner → `resvg-win-aarch64.zip`, `usvg-win-aarch64.zip`

Updates the workflow's actions, two of which still declared the end-of-life node12 runtime:

- `alexellis/upload-assets` 0.2.2 → 0.5.0 (node12 → node24)
- `battila7/get-version-action` removed — unmaintained since 2021 and node12; the workflow only triggers on `v*` tags, so the version is just `${GITHUB_REF_NAME#v}`
- `actions/checkout` v2 → v7, `softprops/action-gh-release` v2 → v3

Renames the existing job to explicitly say `x86_64` and differentiate `aarch64`

Closes #968