### PR TITLE
Convert CI release job to use a Matrix

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -14,10 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
-        id: create_release
         uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref_name }}
@@ -28,16 +28,33 @@ jobs:
             Check [CHANGELOG](https://github.com/linebender/resvg/blob/${{ github.ref }}/CHANGELOG.md).
           draft: false
           prerelease: false
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
 
-  release-linux:
-    name: Release Linux (x86_64)
-    runs-on: ubuntu-latest
+  release-binaries:
+    name: Release ${{ matrix.os }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     needs: ["create-release"]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: linux, arch: x86_64,  runner: ubuntu-latest }
+          - { os: linux, arch: aarch64, runner: ubuntu-24.04-arm }
+          - { os: win,   arch: x86_64,  runner: windows-latest }
+          - { os: win,   arch: aarch64, runner: windows-11-arm }
+          - { os: macos, arch: x86_64,  runner: macos-15-intel }
+          - { os: macos, arch: aarch64, runner: macos-latest }
+    env:
+      SUFFIX: ${{ matrix.os }}-${{ matrix.arch }}
+      # Statically link the MSVC CRT on Windows.
+      RUSTFLAGS: ${{ matrix.os == 'win' && '-Ctarget-feature=+crt-static' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Some weird CI glitch. Make sure we have the latest Rust.
+      - name: Install latest stable toolchain
+        if: matrix.os == 'macos'
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build resvg
         run: cargo build --release
@@ -46,16 +63,45 @@ jobs:
         working-directory: crates/usvg
         run: cargo build --release
 
-      - name: Collect
+      - name: Compress (Linux)
+        if: matrix.os == 'linux'
         working-directory: target/release
         run: |
           strip -s resvg
           strip -s usvg
-          tar czf resvg-linux-x86_64.tar.gz resvg
-          tar czf usvg-linux-x86_64.tar.gz usvg
-          mkdir ../../bin
-          cp resvg-linux-x86_64.tar.gz ../../bin/
-          cp usvg-linux-x86_64.tar.gz ../../bin/
+          tar czf resvg-$SUFFIX.tar.gz resvg
+          tar czf usvg-$SUFFIX.tar.gz usvg
+
+      - name: Compress (macOS)
+        if: matrix.os == 'macos'
+        working-directory: target/release
+        run: |
+          7z a -tzip -mx9 resvg-$SUFFIX.zip resvg
+          7z a -tzip -mx9 usvg-$SUFFIX.zip usvg
+
+      - name: Compress (Windows)
+        if: matrix.os == 'win'
+        working-directory: target/release
+        shell: cmd
+        run: |
+          7z a -tzip -mx9 resvg-%SUFFIX%.zip resvg.exe
+          7z a -tzip -mx9 usvg-%SUFFIX%.zip usvg.exe
+
+      - name: Upload binaries
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref }}
+          files: |
+            target/release/resvg-${{ env.SUFFIX }}.*
+            target/release/usvg-${{ env.SUFFIX }}.*
+
+  release-vendored-archive:
+    name: Release vendored sources archive
+    runs-on: ubuntu-latest
+    needs: ["create-release"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
       - name: Make vendored archive
         run: |
@@ -72,80 +118,25 @@ jobs:
               --exclude="resvg-$VERSION/version-bump.md" \
               --exclude="resvg-$VERSION/docs" \
               -cJf resvg-"$VERSION".tar.xz resvg-"$VERSION"
-          cp resvg-"$VERSION".tar.xz bin/
 
-      - name: Upload binaries
-        uses: alexellis/upload-assets@0.5.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload archive
+        uses: softprops/action-gh-release@v3
         with:
-          asset_paths: '["bin/*"]'
+          tag_name: ${{ github.ref }}
+          files: resvg-*.tar.xz
 
-  release-linux-aarch64:
-    name: Release Linux (aarch64)
-    runs-on: ubuntu-24.04-arm
-    needs: ["create-release"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Build resvg
-        run: cargo build --release
-
-      - name: Build usvg
-        working-directory: crates/usvg
-        run: cargo build --release
-
-      - name: Collect
-        working-directory: target/release
-        run: |
-          strip -s resvg
-          strip -s usvg
-          tar czf resvg-linux-aarch64.tar.gz resvg
-          tar czf usvg-linux-aarch64.tar.gz usvg
-          mkdir ../../bin
-          cp resvg-linux-aarch64.tar.gz ../../bin/
-          cp usvg-linux-aarch64.tar.gz ../../bin/
-
-      - name: Upload binaries
-        uses: alexellis/upload-assets@0.5.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["bin/*"]'
-
-  release-windows:
-    name: Release Windows (x86_64)
+  release-explorer-thumbnailer:
+    name: Release Windows Explorer thumbnailer
     runs-on: windows-latest
     needs: ["create-release"]
+    env:
+      RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      # Toolchain is stable-x86_64-pc-windows-msvc by default. No need to change it.
-
-      - name: Build resvg
-        env:
-          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
-        run: cargo build --release
-
-      - name: Build usvg
-        working-directory: crates/usvg
-        env:
-          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
-        run: cargo build --release
-
-      - name: Compress
-        working-directory: target/release
-        shell: cmd
-        run: |
-          7z a -tzip -mx9 resvg-win64.zip resvg.exe
-          7z a -tzip -mx9 usvg-win64.zip usvg.exe
 
       - name: Build thumbnailer
         working-directory: tools/explorer-thumbnailer
-        env:
-          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
         run: cargo build --release
 
       - name: Build thumbnailer installer
@@ -154,149 +145,8 @@ jobs:
         run: |
           "%programfiles(x86)%\Inno Setup 6\iscc.exe" "installer.iss"
 
-      # Unlike other binaries, viewsvg isn't built with crt-static
-      - name: Build C API
-        working-directory: crates/c-api
-        run: cargo build --release
-
-      - name: Prepare Developer Command Prompt for MSVC
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Collect
-        run: |
-          mkdir bin
-          cp target/release/resvg-win64.zip bin/
-          cp target/release/usvg-win64.zip bin/
-          cp tools/explorer-thumbnailer/install/resvg-explorer-extension.exe bin/
-
-      - name: Upload binaries
-        uses: alexellis/upload-assets@0.5.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload installer
+        uses: softprops/action-gh-release@v3
         with:
-          asset_paths: '["bin/*"]'
-
-  release-windows-aarch64:
-    name: Release Windows (aarch64)
-    runs-on: windows-11-arm
-    needs: ["create-release"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      # Toolchain is stable-aarch64-pc-windows-msvc by default. No need to change it.
-
-      - name: Build resvg
-        env:
-          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
-        run: cargo build --release
-
-      - name: Build usvg
-        working-directory: crates/usvg
-        env:
-          RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
-        run: cargo build --release
-
-      - name: Compress
-        working-directory: target/release
-        shell: cmd
-        run: |
-          7z a -tzip -mx9 resvg-win-aarch64.zip resvg.exe
-          7z a -tzip -mx9 usvg-win-aarch64.zip usvg.exe
-
-      - name: Collect
-        run: |
-          mkdir bin
-          cp target/release/resvg-win-aarch64.zip bin/
-          cp target/release/usvg-win-aarch64.zip bin/
-
-      - name: Upload binaries
-        uses: alexellis/upload-assets@0.5.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["bin/*"]'
-
-  release-macos-aarch64:
-    name: Release macOS (aarch64)
-    runs-on: macos-latest
-    needs: ["create-release"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      # Some weird CI glitch. Make sure we have the latest Rust.
-      - name: Install latest stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build resvg
-        run: cargo build --release
-
-      - name: Build usvg
-        working-directory: crates/usvg
-        run: cargo build --release
-
-      - name: Compress
-        working-directory: target/release
-        run: |
-          7z a -tzip -mx9 resvg-macos-aarch64.zip resvg
-          7z a -tzip -mx9 usvg-macos-aarch64.zip usvg
-
-      - name: Build C API
-        working-directory: crates/c-api
-        run: cargo build --release
-
-      - name: Collect
-        run: |
-          mkdir bin
-          cp target/release/resvg-macos-aarch64.zip bin/
-          cp target/release/usvg-macos-aarch64.zip bin/
-
-      - name: Upload binaries
-        uses: alexellis/upload-assets@0.5.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["bin/*"]'
-
-  release-macos-intel:
-    name: Release macOS (intel)
-    runs-on: macos-15-intel
-    needs: ["create-release"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      # Some weird CI glitch. Make sure we have the latest Rust.
-      - name: Install latest stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build resvg
-        run: cargo build --release
-
-      - name: Build usvg
-        working-directory: crates/usvg
-        run: cargo build --release
-
-      - name: Compress
-        working-directory: target/release
-        run: |
-          7z a -tzip -mx9 resvg-macos-x86_64.zip resvg
-          7z a -tzip -mx9 usvg-macos-x86_64.zip usvg
-
-      - name: Build C API
-        working-directory: crates/c-api
-        run: cargo build --release
-
-      - name: Collect
-        run: |
-          mkdir bin
-          cp target/release/resvg-macos-x86_64.zip bin/
-          cp target/release/usvg-macos-x86_64.zip bin/
-
-      - name: Upload binaries
-        uses: alexellis/upload-assets@0.5.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["bin/*"]'
+          tag_name: ${{ github.ref }}
+          files: tools/explorer-thumbnailer/install/resvg-explorer-extension.exe


### PR DESCRIPTION
Some CI cleanup suggested by LLM review of https://github.com/linebender/resvg/pull/1132. Has been verified as working on my fork.

## Changes made

- Collapse the six per-platform release-* jobs into one release-binaries matrix job over {linux, win, macos} × {x86_64, aarch64}. Asset names are derived from the matrix (`resvg-$SUFFIX.{tar.gz,zip}`). This renamea `resvg-win64.zip` / `usvg-win64.zip` to `resvg-win-x86_64.zip` / `usvg-win-x86_64.zip` to match the linux-* / macos-* / win-aarch64 naming. This is a breaking change for anyone scripting downloads of the old names.
- Drop the crates/c-api release builds (and the ilammy/msvc-dev-cmd step): their output was never collected or uploaded, so they only cost CI time.
- Split the vendored sources archive and the Windows Explorer thumbnailer into their own jobs
- Upload assets with `softprops/action-gh-release@v3` files: (already used to create the release) instead of the third-party `alexellis/upload-assets`.

